### PR TITLE
Xindi/keyboard control

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -136,7 +136,10 @@
   cursor: default;
 }
 
-.emoji-mart-category .emoji-mart-emoji:hover:before {
+.emoji-mart-category .emoji-mart-emoji:focus { outline: 0 }
+
+.emoji-mart-category .emoji-mart-emoji:hover:before, 
+.emoji-mart-category .emoji-mart-emoji:focus:before {
   z-index: 0;
   content: "";
   position: absolute;
@@ -164,15 +167,14 @@
 }
 
 .emoji-mart-category-list {
+  border-spacing: 0;
   margin: 0;
   padding: 0;
 }
 
-.emoji-mart-category-list li {
-  list-style: none;
+.emoji-mart-category-list td {
   margin: 0;
   padding: 0;
-  display: inline-block;
 }
 
 .emoji-mart-emoji {

--- a/src/components/anchors.js
+++ b/src/components/anchors.js
@@ -14,6 +14,7 @@ export default class Anchors extends React.PureComponent {
     }
 
     this.handleClick = this.handleClick.bind(this)
+    this.setButtonsRef = this.setButtonsRef.bind(this)
   }
 
   handleClick(e) {
@@ -23,12 +24,20 @@ export default class Anchors extends React.PureComponent {
     onAnchorClick(categories[index], index)
   }
 
+  setButtonsRef(c) {
+    this.buttons = c
+  }
+
   render() {
     var { categories, color, i18n, icons } = this.props,
       { selected } = this.state
 
     return (
-      <nav className="emoji-mart-anchors" aria-label={i18n.categorieslabel}>
+      <nav
+        className="emoji-mart-anchors"
+        aria-label={i18n.categorieslabel}
+        ref={this.setButtonsRef}
+      >
         {categories.map((category, i) => {
           var { id, name, anchor } = category,
             isSelected = name == selected

--- a/src/components/category.js
+++ b/src/components/category.js
@@ -13,6 +13,7 @@ export default class Category extends React.Component {
     this.data = props.data
     this.setContainerRef = this.setContainerRef.bind(this)
     this.setLabelRef = this.setLabelRef.bind(this)
+    this.setEmojiTableRef = this.setEmojiTableRef.bind(this)
   }
 
   componentDidMount() {
@@ -145,6 +146,10 @@ export default class Category extends React.Component {
     this.container = c
   }
 
+  setEmojiTableRef(c) {
+    this.emojiTableRef = c
+  }
+
   setLabelRef(c) {
     this.label = c
   }
@@ -158,6 +163,7 @@ export default class Category extends React.Component {
         i18n,
         notFound,
         notFoundEmoji,
+        perLine,
       } = this.props,
       emojis = this.getEmojis(),
       labelStyles = {},
@@ -182,6 +188,52 @@ export default class Category extends React.Component {
 
     const label = i18n.categories[id] || name
 
+    const EmojiTable = ({ emojis }) => {
+      var trs = []
+      for (let i = 0; i < emojis.length; i += perLine) {
+        trs.push(
+          <tr role="row" key={`emoji-row-${i}`}>
+            {emojis.slice(i, i + perLine).map((emoji, j) => (
+              <td
+                role="gridcell"
+                tabIndex="-1"
+                key={
+                  (emoji.short_names && emoji.short_names.join('_')) || emoji
+                }
+              >
+                {NimbleEmoji({
+                  emoji: emoji,
+                  data: this.data,
+                  ...emojiProps,
+                  onKeyDown: (e, emoji) => {
+                    emojiProps.onKeyDown(
+                      e,
+                      emoji,
+                      {
+                        category: id,
+                        row: Math.floor(i / perLine),
+                        column: j,
+                      },
+                      this.emojiTableRef,
+                    )
+                  },
+                })}
+              </td>
+            ))}
+          </tr>,
+        )
+      }
+      return (
+        <table
+          ref={this.setEmojiTableRef}
+          className="emoji-mart-category-list"
+          role="grid"
+        >
+          <tbody>{trs}</tbody>
+        </table>
+      )
+    }
+
     return (
       <section
         ref={this.setContainerRef}
@@ -203,18 +255,7 @@ export default class Category extends React.Component {
           </span>
         </div>
 
-        <ul className="emoji-mart-category-list">
-          {emojis &&
-            emojis.map((emoji) => (
-              <li
-                key={
-                  (emoji.short_names && emoji.short_names.join('_')) || emoji
-                }
-              >
-                {NimbleEmoji({ emoji: emoji, data: this.data, ...emojiProps })}
-              </li>
-            ))}
-        </ul>
+        {emojis && <EmojiTable emojis={emojis} />}
 
         {emojis && !emojis.length && (
           <NotFound

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -212,6 +212,7 @@ const NimbleEmoji = (props) => {
   } else {
     return (
       <Tag.name
+        id={`emoji-mart-${props.emoji}`}
         onKeyDown={(e) => _handleKeyDown(e, props)}
         onClick={(e) => _handleClick(e, props)}
         onMouseEnter={(e) => _handleOver(e, props)}

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -54,6 +54,18 @@ const _handleLeave = (e, props) => {
   onLeave(emoji, e)
 }
 
+const _handleKeyDown = (e, props) => {
+  e.preventDefault()
+
+  if (!props.onKeyDown) {
+    return
+  }
+  var { onKeyDown } = props,
+    emoji = _getSanitizedData(props)
+
+  onKeyDown(e, emoji)
+}
+
 const _isNumeric = (value) => {
   return !isNaN(value - parseFloat(value))
 }
@@ -188,6 +200,7 @@ const NimbleEmoji = (props) => {
     Tag.name = 'button'
     Tag.props = {
       type: 'button',
+      tabIndex: '-1',
     }
   }
 
@@ -199,6 +212,7 @@ const NimbleEmoji = (props) => {
   } else {
     return (
       <Tag.name
+        onKeyDown={(e) => _handleKeyDown(e, props)}
         onClick={(e) => _handleClick(e, props)}
         onMouseEnter={(e) => _handleOver(e, props)}
         onMouseLeave={(e) => _handleLeave(e, props)}

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -64,7 +64,7 @@ export default class NimblePicker extends React.PureComponent {
     this.data = props.data
     this.i18n = deepMerge(I18N, props.i18n)
     this.icons = deepMerge(icons, props.icons)
-    this.state = { firstRender: true }
+    this.state = { firstRender: true, emoji: null }
 
     this.categories = []
     let allCategories = [].concat(this.data.categories)
@@ -273,7 +273,7 @@ export default class NimblePicker extends React.PureComponent {
       }
     }
 
-    preview.setState({ emoji })
+    this.setState({ emoji })
     clearTimeout(this.leaveTimeout)
   }
 
@@ -284,7 +284,7 @@ export default class NimblePicker extends React.PureComponent {
     }
 
     this.leaveTimeout = setTimeout(() => {
-      preview.setState({ emoji: null })
+      this.setState({ emoji: null })
     }, 16)
   }
 
@@ -435,13 +435,13 @@ export default class NimblePicker extends React.PureComponent {
       }
     }
 
-    preview.setState({ emoji: emojiToPreview })
+    this.setState({ emoji: emojiToPreview })
     clearTimeout(this.leaveTimeout)
   }
 
   handleEmojiClick(emoji, e) {
     this.props.onClick(emoji, e)
-    // this.handleEmojiSelect(emoji)
+    this.handleEmojiSelect(emoji)
   }
 
   handleEmojiSelect(emoji) {
@@ -615,6 +615,11 @@ export default class NimblePicker extends React.PureComponent {
         }
         break
 
+      case 27: // escape
+        this.search.input.focus()
+        handled = true
+        break
+
       case 40: // down arrow
         const activeCategory = this.anchors.state.selected
         const activeCategoryIndex = this.categories.findIndex(
@@ -630,6 +635,7 @@ export default class NimblePicker extends React.PureComponent {
         break
 
       default:
+        // console.log(this.search)
         break
     }
 
@@ -691,7 +697,7 @@ export default class NimblePicker extends React.PureComponent {
       sheetRows,
       style,
       title,
-      emoji,
+      emoji: idleEmoji,
       color,
       native,
       backgroundImageFn,
@@ -708,6 +714,9 @@ export default class NimblePicker extends React.PureComponent {
       notFound,
       notFoundEmoji,
     } = this.props
+
+    const { emoji } = this.state
+    const pickerId = 'emoji-mart-picker'
 
     var width = perLine * (emojiSize + 12) + 12 + 2 + measureScrollbar()
     var theme = this.getPreferredTheme()
@@ -742,13 +751,16 @@ export default class NimblePicker extends React.PureComponent {
           data={this.data}
           i18n={this.i18n}
           emojisToShowFilter={emojisToShowFilter}
+          emoji={emoji}
           include={include}
           exclude={exclude}
           custom={this.CUSTOM}
           autoFocus={autoFocus}
+          pickerId={pickerId}
         />
 
         <div
+          id={pickerId}
           ref={this.setScrollRef}
           className="emoji-mart-scroll"
           onScroll={this.handleScroll}
@@ -805,6 +817,7 @@ export default class NimblePicker extends React.PureComponent {
               data={this.data}
               title={title}
               emoji={emoji}
+              idleEmoji={idleEmoji}
               showSkinTones={showSkinTones}
               showPreview={showPreview}
               emojiProps={{

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -312,13 +312,13 @@ export default class NimblePicker extends React.PureComponent {
     let emojiIndex
     const lastEmojiIndex = getLastEmojiIndex(categoryIndex)
 
-    switch (e.keyCode) {
-      case 9: // tab
+    switch (e.key) {
+      case 'Tab':
         // Focus on first category anchor
         this.anchors.buttons.firstChild.focus()
         return
 
-      case 37: // left arrow
+      case 'ArrowLeft':
         newRow = row
         newColumn = column - 1
         // Get Emoji at (row, column - 1) or (row - 1, lastColumn)
@@ -333,7 +333,7 @@ export default class NimblePicker extends React.PureComponent {
         }
         break
 
-      case 38: // up arrow
+      case 'ArrowUp':
         newRow = row - 1
         newColumn = column
         // Get Emoji at (row - 1, column)
@@ -369,7 +369,7 @@ export default class NimblePicker extends React.PureComponent {
         }
         break
 
-      case 39: // right arrow
+      case 'ArrowRight':
         newRow = row
         newColumn = column + 1
         // Get Emoji at (row, column + 1) or on (row + 1, 0)
@@ -384,7 +384,7 @@ export default class NimblePicker extends React.PureComponent {
         }
         break
 
-      case 40: // down arrow
+      case 'ArrowDown':
         newRow = row + 1
         newColumn = column
         // Get Emoji at (row + 1, column)
@@ -596,8 +596,8 @@ export default class NimblePicker extends React.PureComponent {
   handleKeyDown(e) {
     let handled = false
 
-    switch (e.keyCode) {
-      case 13: // enter
+    switch (e.key) {
+      case 'Enter':
         let emoji
 
         if (
@@ -615,12 +615,13 @@ export default class NimblePicker extends React.PureComponent {
         }
         break
 
-      case 27: // escape
+      case 'Escape':
+        // Jump to search text input
         this.search.input.focus()
         handled = true
         break
 
-      case 40: // down arrow
+      case 'ArrowDown':
         const activeCategory = this.anchors.state.selected
         const activeCategoryIndex = this.categories.findIndex(
           ({ name }) => name === activeCategory,
@@ -635,7 +636,6 @@ export default class NimblePicker extends React.PureComponent {
         break
 
       default:
-        // console.log(this.search)
         break
     }
 

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -178,7 +178,7 @@ export default class NimblePicker extends React.PureComponent {
     }
 
     this.categories.unshift(this.SEARCH_CATEGORY)
-
+    this.getEmojiIndex = this.getEmojiIndex.bind(this)
     this.setAnchorsRef = this.setAnchorsRef.bind(this)
     this.handleAnchorClick = this.handleAnchorClick.bind(this)
     this.setSearchRef = this.setSearchRef.bind(this)
@@ -190,6 +190,7 @@ export default class NimblePicker extends React.PureComponent {
     this.handleEmojiLeave = this.handleEmojiLeave.bind(this)
     this.handleEmojiClick = this.handleEmojiClick.bind(this)
     this.handleEmojiSelect = this.handleEmojiSelect.bind(this)
+    this.handleEmojiKeyDown = this.handleEmojiKeyDown.bind(this)
     this.setPreviewRef = this.setPreviewRef.bind(this)
     this.handleSkinChange = this.handleSkinChange.bind(this)
     this.handleKeyDown = this.handleKeyDown.bind(this)
@@ -247,6 +248,11 @@ export default class NimblePicker extends React.PureComponent {
     return this.darkMatchMedia.matches ? 'dark' : 'light'
   }
 
+  getEmojiIndex(row, column) {
+    const { perLine } = this.props
+    return row * perLine + column
+  }
+
   handleDarkMatchMediaChange() {
     this.setState({ theme: this.darkMatchMedia.matches ? 'dark' : 'light' })
   }
@@ -282,9 +288,160 @@ export default class NimblePicker extends React.PureComponent {
     }, 16)
   }
 
+  handleEmojiKeyDown(e, _, { category, row, column }) {
+    const { perLine } = this.props
+    const categoryIndex = this.categories.findIndex(({ id }) => id === category)
+
+    const getEmojiInCategory = (categoryIndex) => {
+      const emojisInCategory =
+        categoryIndex === 1
+          ? frequently.get(perLine)
+          : this.categories[categoryIndex].emojis
+      return emojisInCategory
+    }
+
+    const getLastEmojiIndex = (categoryIndex) => {
+      const emojisInCategory = getEmojiInCategory(categoryIndex)
+      const lastEmojiIndex = emojisInCategory.length - 1
+      return lastEmojiIndex
+    }
+
+    let newRow
+    let newColumn
+    let newCategoryIndex = categoryIndex
+    let emojiIndex
+    const lastEmojiIndex = getLastEmojiIndex(categoryIndex)
+
+    switch (e.keyCode) {
+      case 9: // tab
+        // Focus on first category anchor
+        this.anchors.buttons.firstChild.focus()
+        return
+
+      case 37: // left arrow
+        newRow = row
+        newColumn = column - 1
+        // Get Emoji at (row, column - 1) or (row - 1, lastColumn)
+        emojiIndex = this.getEmojiIndex(newRow, newColumn)
+        if (emojiIndex < 0) {
+          newCategoryIndex = categoryIndex - 1
+          if (newCategoryIndex < 1) {
+            return
+          }
+          // Get last Emoji in previous category
+          emojiIndex = getLastEmojiIndex(newCategoryIndex)
+        }
+        break
+
+      case 38: // up arrow
+        newRow = row - 1
+        newColumn = column
+        // Get Emoji at (row - 1, column)
+        emojiIndex = this.getEmojiIndex(newRow, newColumn)
+        if (emojiIndex < 0) {
+          newCategoryIndex = categoryIndex - 1
+          if (newCategoryIndex < 1) {
+            return
+          }
+          let numOfItemsOnLastRow =
+            getEmojiInCategory(newCategoryIndex).length % perLine
+
+          if (numOfItemsOnLastRow === 0) {
+            // If last row of previous category is full
+            // Get Emoji in previous category at (lastRow, column)
+            newRow =
+              Math.floor(
+                getEmojiInCategory(newCategoryIndex).length / perLine,
+              ) - 1
+            emojiIndex = this.getEmojiIndex(newRow, newColumn)
+          } else if (newColumn >= numOfItemsOnLastRow) {
+            // If last row of previous category doesn't have items above current item
+            // Get last Emoji in previous category
+            emojiIndex = getLastEmojiIndex(newCategoryIndex)
+          } else {
+            // If last row of previous category has items above current item
+            // Get Emoji in previous category at (lastRow, column)
+            newRow = Math.floor(
+              getEmojiInCategory(newCategoryIndex).length / perLine,
+            )
+            emojiIndex = this.getEmojiIndex(newRow, newColumn)
+          }
+        }
+        break
+
+      case 39: // right arrow
+        newRow = row
+        newColumn = column + 1
+        // Get Emoji at (row, column + 1) or on (row + 1, 0)
+        emojiIndex = this.getEmojiIndex(newRow, newColumn)
+        if (emojiIndex > lastEmojiIndex) {
+          newCategoryIndex = categoryIndex + 1
+          if (newCategoryIndex >= this.categories.length) {
+            return
+          }
+          // Get first Emoji in next category
+          emojiIndex = 0
+        }
+        break
+
+      case 40: // down arrow
+        newRow = row + 1
+        newColumn = column
+        // Get Emoji at (row + 1, column)
+        emojiIndex = this.getEmojiIndex(newRow, newColumn)
+        if (emojiIndex > lastEmojiIndex) {
+          newCategoryIndex = categoryIndex + 1
+          if (newCategoryIndex >= this.categories.length) {
+            return
+          }
+          // Get Emoji in next category at (0, column)
+          emojiIndex = this.getEmojiIndex(0, newColumn)
+        }
+        break
+      default:
+        return
+    }
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    const emojis = getEmojiInCategory(newCategoryIndex)
+    const categoryRef = this.categoryRefs[`category-${newCategoryIndex}`]
+    const cells = categoryRef.emojiTableRef.querySelectorAll('button')
+    const emojiEl = cells[emojiIndex]
+    const emoji = emojis[emojiIndex]
+
+    emojiEl.focus()
+
+    const emojiToPreview = getSanitizedData(
+      emoji,
+      this.state.skin,
+      this.props.set,
+      this.props.data,
+    )
+
+    var { preview } = this
+    if (!preview) {
+      return
+    }
+
+    const emojiData = this.CUSTOM.filter(
+      (customEmoji) => customEmoji.id === emojiToPreview.id,
+    )[0]
+
+    for (let key in emojiData) {
+      if (emojiData.hasOwnProperty(key)) {
+        emoji[key] = emojiData[key]
+      }
+    }
+
+    preview.setState({ emoji: emojiToPreview })
+    clearTimeout(this.leaveTimeout)
+  }
+
   handleEmojiClick(emoji, e) {
     this.props.onClick(emoji, e)
-    this.handleEmojiSelect(emoji)
+    // this.handleEmojiSelect(emoji)
   }
 
   handleEmojiSelect(emoji) {
@@ -440,7 +597,7 @@ export default class NimblePicker extends React.PureComponent {
     let handled = false
 
     switch (e.keyCode) {
-      case 13:
+      case 13: // enter
         let emoji
 
         if (
@@ -456,7 +613,23 @@ export default class NimblePicker extends React.PureComponent {
           this.handleEmojiSelect(emoji)
           handled = true
         }
+        break
 
+      case 40: // down arrow
+        const activeCategory = this.anchors.state.selected
+        const activeCategoryIndex = this.categories.findIndex(
+          ({ name }) => name === activeCategory,
+        )
+        const { container } = this.categoryRefs[
+          `category-${activeCategoryIndex}`
+        ]
+
+        const firstEmoji = container.querySelector('button')
+        firstEmoji.focus()
+        handled = true
+        break
+
+      default:
         break
     }
 
@@ -616,6 +789,7 @@ export default class NimblePicker extends React.PureComponent {
                   onOver: this.handleEmojiOver,
                   onLeave: this.handleEmojiLeave,
                   onClick: this.handleEmojiClick,
+                  onKeyDown: this.handleEmojiKeyDown,
                 }}
                 notFound={notFound}
                 notFoundEmoji={notFoundEmoji}

--- a/src/components/preview.js
+++ b/src/components/preview.js
@@ -11,20 +11,19 @@ export default class Preview extends React.PureComponent {
     super(props)
 
     this.data = props.data
-    this.state = { emoji: null }
   }
 
   render() {
-    var { emoji } = this.state,
-      {
-        emojiProps,
-        skinsProps,
-        showSkinTones,
-        title,
-        emoji: idleEmoji,
-        i18n,
-        showPreview,
-      } = this.props
+    const {
+      emoji,
+      emojiProps,
+      idleEmoji,
+      skinsProps,
+      showSkinTones,
+      title,
+      i18n,
+      showPreview,
+    } = this.props
 
     if (emoji && showPreview) {
       var emojiData = getData(emoji, null, null, this.data),
@@ -77,7 +76,11 @@ export default class Preview extends React.PureComponent {
           <div className="emoji-mart-preview-emoji" aria-hidden="true">
             {idleEmoji &&
               idleEmoji.length &&
-              NimbleEmoji({ emoji: idleEmoji, data: this.data, ...emojiProps })}
+              NimbleEmoji({
+                emoji: idleEmoji,
+                data: this.data,
+                ...emojiProps,
+              })}
           </div>
 
           <div className="emoji-mart-preview-data" aria-hidden="true">
@@ -117,7 +120,8 @@ export default class Preview extends React.PureComponent {
 Preview.propTypes /* remove-proptypes */ = {
   showSkinTones: PropTypes.bool,
   title: PropTypes.string.isRequired,
-  emoji: PropTypes.string.isRequired,
+  idleEmoji: PropTypes.string.isRequired,
+  emoji: PropTypes.object.isRequired,
   emojiProps: PropTypes.object.isRequired,
   skinsProps: PropTypes.object.isRequired,
 }

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -79,26 +79,39 @@ export default class Search extends React.PureComponent {
   }
 
   render() {
-    const { i18n, autoFocus } = this.props
+    const { i18n, autoFocus, emoji, pickerId } = this.props
     const { icon, isSearching, id } = this.state
     const inputId = `emoji-mart-search-${id}`
+    const descriptionId = 'emoji-mart-search-description'
 
     return (
       <section className="emoji-mart-search" aria-label={i18n.search}>
         <input
           id={inputId}
           ref={this.setRef}
-          type="search"
           onChange={this.handleChange}
           placeholder={i18n.search}
           autoFocus={autoFocus}
+          type="text"
+          placeholder="Search"
+          role="textbox"
+          aria-owns={pickerId}
+          aria-label="Search for an emoji"
+          aria-describedby={descriptionId}
+          aria-activedescendant={emoji ? `emoji-mart-${emoji.id}` : ''}
         />
         {/*
          * Use a <label> in addition to the placeholder for accessibility, but place it off-screen
          * http://www.maxability.co.in/2016/01/placeholder-attribute-and-why-it-is-not-accessible/
          */}
-        <label className="emoji-mart-sr-only" htmlFor={inputId}>
-          {i18n.search}
+        <label
+          className="emoji-mart-sr-only"
+          htmlFor={inputId}
+          id={descriptionId}
+        >
+          {i18n.search}: Use the left, right, up and down arrow keys to navigate
+          the emoji search results. Use escape key to deselect an emoji and
+          focus on search bar.
         </label>
         <button
           className="emoji-mart-search-icon"
@@ -115,6 +128,7 @@ export default class Search extends React.PureComponent {
 }
 
 Search.propTypes /* remove-proptypes */ = {
+  emoji: PropTypes.object,
   onSearch: PropTypes.func,
   maxResults: PropTypes.number,
   emojisToShowFilter: PropTypes.func,
@@ -122,6 +136,7 @@ Search.propTypes /* remove-proptypes */ = {
 }
 
 Search.defaultProps = {
+  emoji: null,
   onSearch: () => {},
   maxResults: 75,
   emojisToShowFilter: null,


### PR DESCRIPTION
Exactly the same as [PR in original repo](https://github.com/missive/emoji-mart/pull/431)

# Changes
Added keyboard control:

## Category anchors:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/27241590/82694732-688ec280-9c29-11ea-8b17-6d9f3fc3336e.gif)

- When focusing on any emoji, <kbd>Tab</kbd> to change focus to the first category anchor
- When a category is selected, <kbd>Arrow Down</kbd> to go to the first item in the category 
- This also means that when focusing on any emoji, <kbd>Tab</kbd> can no longer used to go to the next emoji
- Same applies to search
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/27241590/82694846-9e33ab80-9c29-11ea-96f1-09c453621f25.gif)

## Emoji:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27241590/82694567-1483de00-9c29-11ea-83a4-66915bac4581.gif)

- <kbd>Arrow Up</kbd>, <kbd>Arrow Down</kbd>, <kbd>Arrow Left</kbd>, <kbd>Arrow Right</kbd> to go to emojis on top/down/left/right to the current emoji
- Able to jump to next/previous category if at the last line/first row

## Style:
- emoji focus style now should look the same as emoji on hover style

## Markup:
- Change emoji layout to table/cell with a11y roles

References:
- This PR is largely inspired by #348. Note that some of the features mentioned are not implemented or implemented differently. 
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role
- Slack emoji picker 

